### PR TITLE
Minor fixes in calendar events

### DIFF
--- a/src/app/components/CalendarEventForm.svelte
+++ b/src/app/components/CalendarEventForm.svelte
@@ -65,7 +65,7 @@
       tags: [
         ["d", initialValues?.d || randomId()],
         ["title", title],
-        ["location", location],
+        ["location", location || ""],
         ["start", start.toString()],
         ["end", end.toString()],
         ...daysBetween(start, end).map(D => ["D", D.toString()]),


### PR DESCRIPTION
This addresses problems that may be related to issue #118.

The makeCalendarFeed function was introduced in the project a few days before the issue was opened, so I believe it may be related to the perceived problem.

In my tests, the function works fine with a local test relay but not with remote relays. I suspect that the number of requests, with dozens of tags to filter, is overwhelming for remote relays.


There was a minor bug where an empty location would cause the calendar event publication to fail.