### PR TITLE
Add mobile deep linking support

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="app.flotilla.social" />
             </intent-filter>
         </activity>
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -20,6 +20,12 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+            </intent-filter>
         </activity>
 
         <provider

--- a/ios/App/Flotilla Chat.entitlements
+++ b/ios/App/Flotilla Chat.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:app.flotilla.social</string>
+	</array>
 </dict>
 </plist>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -110,21 +110,8 @@
 
     // Listen for deep link events
     App.addListener("appUrlOpen", (event: URLOpenListenerEvent) => {
-      console.log(event)
       const url = new URL(event.url)
       const target = `${url.pathname}${url.search}${url.hash}`
-      goto(target, {replaceState: false, noScroll: false})
-    })
-
-    // TEMP: Since the capacitor event won't fire in web, dropping equivalent implementation here for testing navigation
-    //
-    // Event can be manually triggered in web console with: `window.dispatchEvent(new CustomEvent("appUrlOpen", { detail: { url: "foobar:///.well-known/apple-app-site-association" } }) );`
-    window.addEventListener("appUrlOpen", (_event: Event) => {
-      console.log(_event)
-      const event = _event as CustomEvent<{url: string}>
-      const url = new URL(event.detail.url)
-      const target = `${url.pathname}${url.search}${url.hash}`
-      console.log(target)
       goto(target, {replaceState: false, noScroll: false})
     })
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,7 +4,7 @@
   import {onMount} from "svelte"
   import * as nip19 from "nostr-tools/nip19"
   import {get, derived} from "svelte/store"
-  import {App} from "@capacitor/app"
+  import {App, type URLOpenListenerEvent} from "@capacitor/app"
   import {dev} from "$app/environment"
   import {goto} from "$app/navigation"
   import {sync, localStorageProvider} from "@welshman/store"
@@ -106,6 +106,13 @@
       if (event.data && event.data.type === "NAVIGATE") {
         goto(event.data.url)
       }
+    })
+
+    // Listen for deep link events
+    App.addListener("appUrlOpen", (event: URLOpenListenerEvent) => {
+      const url = new URL(event.url)
+      const target = `${url.pathname}${url.search}${url.hash}`
+      goto(target, {replaceState: false, noScroll: false})
     })
 
     // Nstart login

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -110,8 +110,21 @@
 
     // Listen for deep link events
     App.addListener("appUrlOpen", (event: URLOpenListenerEvent) => {
+      console.log(event)
       const url = new URL(event.url)
       const target = `${url.pathname}${url.search}${url.hash}`
+      goto(target, {replaceState: false, noScroll: false})
+    })
+
+    // TEMP: Since the capacitor event won't fire in web, dropping equivalent implementation here for testing navigation
+    //
+    // Event can be manually triggered in web console with: `window.dispatchEvent(new CustomEvent("appUrlOpen", { detail: { url: "foobar:///.well-known/apple-app-site-association" } }) );`
+    window.addEventListener("appUrlOpen", (_event: Event) => {
+      console.log(_event)
+      const event = _event as CustomEvent<{url: string}>
+      const url = new URL(event.detail.url)
+      const target = `${url.pathname}${url.search}${url.hash}`
+      console.log(target)
       goto(target, {replaceState: false, noScroll: false})
     })
 

--- a/static/.well-known/apple-app-site-association
+++ b/static/.well-known/apple-app-site-association
@@ -1,0 +1,11 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "TODO",
+        "paths": ["*"]
+      }
+    ]
+  }
+}

--- a/static/.well-known/apple-app-site-association
+++ b/static/.well-known/apple-app-site-association
@@ -3,7 +3,7 @@
     "apps": [],
     "details": [
       {
-        "appID": "TODO",
+        "appID": "S26U9DYW3A.social.flotilla",
         "paths": ["*"]
       }
     ]

--- a/static/.well-known/assetlinks.json
+++ b/static/.well-known/assetlinks.json
@@ -1,0 +1,10 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "TODO",
+      "sha256_cert_fingerprints": ["TODO"]
+    }
+  }
+]

--- a/static/.well-known/assetlinks.json
+++ b/static/.well-known/assetlinks.json
@@ -3,8 +3,11 @@
     "relation": ["delegate_permission/common.handle_all_urls"],
     "target": {
       "namespace": "android_app",
-      "package_name": "TODO",
-      "sha256_cert_fingerprints": ["TODO"]
+      "package_name": "social.flotilla",
+      "sha256_cert_fingerprints": [
+        "D0:2A:2E:82:75:92:4D:E2:13:E8:46:B8:EA:09:15:17:7F:46:7B:D1:49:E3:12:60:F0:01:D3:EF:42:9B:A2:DA",
+        "6D:AF:68:3E:1C:A8:3A:4C:D8:85:73:E9:73:9E:2A:A9:44:C8:5D:56:15:4E:34:42:30:55:7C:FF:ED:4A:D7:8C"
+      ]
     }
   }
 ]


### PR DESCRIPTION
Fixes #148 

Motivation
---
While on mobile, links for `app.flotilla.social` clicked outside of the application, should open up in the app, and preserve path, query, and hash data from URL.

Modifications
---
- Update iOS/Android configs with appropriate entitlement/intent configuration
- Add iOS/Android site associations to appropriate .well-known routes
- Add event listeners for `appUrlOpen` event, to handle routing after application open