### PR TITLE
Auth errors

### DIFF
--- a/src/app/components/ModalContainer.svelte
+++ b/src/app/components/ModalContainer.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
-  import {page} from "$app/stores"
   import Drawer from "@lib/components/Drawer.svelte"
   import Dialog from "@lib/components/Dialog.svelte"
-  import {modals, clearModals} from "@app/util/modal"
+  import {modal, clearModals} from "@app/util/modal"
 
   const onKeyDown = (e: any) => {
     if (e.code === "Escape" && e.target === document.body) {
@@ -10,22 +9,21 @@
     }
   }
 
-  const hash = $derived($page.url.hash.slice(1))
-  const modal = $derived($modals[hash])
+  const m = $derived($modal)
 </script>
 
 <svelte:window onkeydown={onKeyDown} />
 
-{#if modal?.options?.drawer}
-  <Drawer onClose={clearModals} {...modal.options}>
-    {#key modal.id}
-      <modal.component {...modal.props} />
+{#if m?.options?.drawer}
+  <Drawer onClose={clearModals} {...m.options}>
+    {#key m.id}
+      <m.component {...m.props} />
     {/key}
   </Drawer>
-{:else if modal}
-  <Dialog onClose={clearModals} {...modal.options}>
-    {#key modal.id}
-      <modal.component {...modal.props} />
+{:else if m}
+  <Dialog onClose={clearModals} {...m.options}>
+    {#key m.id}
+      <m.component {...m.props} />
     {/key}
   </Dialog>
 {/if}

--- a/src/app/components/SpaceJoinConfirm.svelte
+++ b/src/app/components/SpaceJoinConfirm.svelte
@@ -1,10 +1,12 @@
 <script module lang="ts">
   import {goto} from "$app/navigation"
+  import {dissoc} from "@welshman/lib"
   import {ROOM_META} from "@welshman/util"
   import {load} from "@welshman/net"
+  import {pushToast} from "@app/util/toast"
   import {makeSpacePath} from "@app/util/routes"
   import {addSpaceMembership, broadcastUserData} from "@app/core/commands"
-  import {pushToast} from "@app/util/toast"
+  import {relaysMostlyRestricted} from "@app/core/state"
 
   export const confirmSpaceJoin = async (url: string) => {
     await addSpaceMembership(url)
@@ -19,12 +21,9 @@
     }
 
     broadcastUserData([url])
-
     goto(path, {replaceState: true})
-
-    pushToast({
-      message: "Welcome to the space!",
-    })
+    relaysMostlyRestricted.update(dissoc(url))
+    pushToast({message: "Welcome to the space!"})
   }
 </script>
 

--- a/src/app/core/commands.ts
+++ b/src/app/core/commands.ts
@@ -246,11 +246,7 @@ export const checkRelayAccess = async (url: string, claim = "") => {
 
   await attemptAuth(url)
 
-  const thunk = publishThunk({
-    event: makeEvent(AUTH_JOIN, {tags: [["claim", claim]]}),
-    relays: [url],
-  })
-
+  const thunk = publishJoinRequest({url, claim})
   const error = await getThunkError(thunk)
 
   if (error) {
@@ -296,7 +292,7 @@ export const checkRelayConnection = async (url: string) => {
   }
 }
 
-export const checkRelayAuth = async (url: string, timeout = 3000) => {
+export const checkRelayAuth = async (url: string) => {
   const socket = Pool.get().get(url)
   const okStatuses = [AuthStatus.None, AuthStatus.Ok]
 
@@ -325,7 +321,7 @@ export const attemptRelayAccess = async (url: string, claim = "") => {
   }
 }
 
-// Actions
+// Deletions
 
 export type DeleteParams = {
   protect: boolean
@@ -351,6 +347,8 @@ export const makeDelete = ({protect, event, tags = []}: DeleteParams) => {
 export const publishDelete = ({relays, ...params}: DeleteParams & {relays: string[]}) =>
   publishThunk({event: makeDelete(params), relays})
 
+// Reports
+
 export type ReportParams = {
   event: TrustedEvent
   content: string
@@ -373,6 +371,8 @@ export const publishReport = ({
   content,
 }: ReportParams & {relays: string[]}) =>
   publishThunk({event: makeReport({event, reason, content}), relays})
+
+// Reactions
 
 export type ReactionParams = {
   protect: boolean
@@ -399,6 +399,8 @@ export const makeReaction = ({protect, content, event, tags: paramTags = []}: Re
 export const publishReaction = ({relays, ...params}: ReactionParams & {relays: string[]}) =>
   publishThunk({event: makeReaction(params), relays})
 
+// Comments
+
 export type CommentParams = {
   event: TrustedEvent
   content: string
@@ -410,6 +412,8 @@ export const makeComment = ({event, content, tags = []}: CommentParams) =>
 
 export const publishComment = ({relays, ...params}: CommentParams & {relays: string[]}) =>
   publishThunk({event: makeComment(params), relays})
+
+// Alerts
 
 export type AlertParams = {
   feed: Feed
@@ -493,6 +497,19 @@ export const addTrustedRelay = async (url: string) =>
 
 export const removeTrustedRelay = async (url: string) =>
   publishSettings({trusted_relays: remove(url, userSettingsValues.get().trusted_relays)})
+
+// Join request
+
+export type JoinRequestParams = {
+  url: string
+  claim: string
+}
+
+export const makeJoinRequest = (params: JoinRequestParams) =>
+  makeEvent(AUTH_JOIN, {tags: [["claim", params.claim]]})
+
+export const publishJoinRequest = (params: JoinRequestParams) =>
+  publishThunk({event: makeJoinRequest(params), relays: [params.url]})
 
 // Lightning
 

--- a/src/app/util/modal.ts
+++ b/src/app/util/modal.ts
@@ -1,7 +1,8 @@
 import type {Component} from "svelte"
-import {writable} from "svelte/store"
+import {derived, writable} from "svelte/store"
 import {randomId, always, assoc, Emitter} from "@welshman/lib"
 import {goto} from "$app/navigation"
+import {page} from "$app/stores"
 
 export type ModalOptions = {
   drawer?: boolean
@@ -20,6 +21,10 @@ export type Modal = {
 export const emitter = new Emitter()
 
 export const modals = writable<Record<string, Modal>>({})
+
+export const modal = derived([page, modals], ([$page, $modals]) => {
+  return $modals[$page.url.hash.slice(1)]
+})
 
 export const pushModal = (
   component: Component<any>,

--- a/src/lib/components/SocketStatusIndicator.svelte
+++ b/src/lib/components/SocketStatusIndicator.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
+  import {throttled} from "@welshman/store"
   import {AuthStatus, SocketStatus} from "@welshman/net"
-  import {deriveSocket} from "@app/core/state"
   import StatusIndicator from "@lib/components/StatusIndicator.svelte"
+  import {deriveSocket, relaysMostlyRestricted} from "@app/core/state"
 
   type Props = {
     url: string
   }
 
   const {url}: Props = $props()
-  const socket = deriveSocket(url)
+  const socket = throttled(800, deriveSocket(url))
 </script>
 
 {#if $socket.status === SocketStatus.Open}
@@ -22,7 +23,7 @@
     <StatusIndicator class="bg-red-500">Failed to Authenticate</StatusIndicator>
   {:else if $socket.auth.status === AuthStatus.PendingResponse}
     <StatusIndicator class="bg-yellow-500">Authenticating</StatusIndicator>
-  {:else if $socket.auth.status === AuthStatus.Forbidden}
+  {:else if $socket.auth.status === AuthStatus.Forbidden || $relaysMostlyRestricted[url]}
     <StatusIndicator class="bg-red-500">Access Denied</StatusIndicator>
   {:else if $socket.auth.status === AuthStatus.Ok}
     <StatusIndicator class="bg-green-500">Connected</StatusIndicator>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -20,6 +20,8 @@
     ago,
     WEEK,
     TaskQueue,
+    assoc,
+    dissoc,
   } from "@welshman/lib"
   import type {TrustedEvent, StampedEvent} from "@welshman/util"
   import {
@@ -40,13 +42,18 @@
     getRelaysFromList,
   } from "@welshman/util"
   import {Nip46Broker, makeSecret} from "@welshman/signer"
-  import type {Socket, RelayMessage} from "@welshman/net"
+  import type {Socket, RelayMessage, ClientMessage} from "@welshman/net"
   import {
     request,
     defaultSocketPolicies,
     makeSocketPolicyAuth,
     SocketEvent,
     isRelayEvent,
+    isRelayOk,
+    isRelayClosed,
+    isClientReq,
+    isClientEvent,
+    isClientClose,
   } from "@welshman/net"
   import {
     loadRelay,
@@ -87,6 +94,7 @@
     ensureUnwrapped,
     canDecrypt,
     getSetting,
+    relaysMostlyRestricted,
   } from "@app/core/state"
   import {loadUserData, listenForNotifications} from "@app/core/requests"
   import {theme} from "@app/util/theme"
@@ -292,6 +300,71 @@
                     relaysPendingTrust.update($r => [...$r, socket.url])
                   }
                 }
+              }
+            }),
+          ]
+
+          return () => {
+            unsubscribers.forEach(call)
+          }
+        },
+        function monitorRestrictedResponses(socket: Socket) {
+          let total = 0
+          let restricted = 0
+          let error = ""
+
+          const pending = new Set<string>()
+
+          const updateStatus = () =>
+            relaysMostlyRestricted.update(
+              restricted > total / 2 ? assoc(socket.url, error) : dissoc(socket.url),
+            )
+
+          const unsubscribers = [
+            on(socket, SocketEvent.Receive, (message: RelayMessage) => {
+              if (isRelayOk(message)) {
+                const [_, id, ok, details = ""] = message
+
+                if (pending.has(id)) {
+                  pending.delete(id)
+
+                  if (!ok && details.startsWith("restricted: ")) {
+                    restricted++
+                    error = details
+                    updateStatus()
+                  }
+                }
+              }
+
+              if (isRelayClosed(message)) {
+                const [_, id, details = ""] = message
+
+                if (pending.has(id)) {
+                  pending.delete(id)
+
+                  if (details.startsWith("restricted: ")) {
+                    restricted++
+                    error = details
+                    updateStatus()
+                  }
+                }
+              }
+            }),
+            on(socket, SocketEvent.Send, (message: ClientMessage) => {
+              if (isClientReq(message)) {
+                total++
+                pending.add(message[1])
+                updateStatus()
+              }
+
+              if (isClientEvent(message)) {
+                total++
+                pending.add(message[1].id)
+                updateStatus()
+              }
+
+              if (isClientClose(message)) {
+                pending.delete(message[1])
               }
             }),
           ]


### PR DESCRIPTION
- Fixes #196 
- Adds `modal` store for easier use elsewhere
- Changes relay health check to use a store instead of promises
- Monitors restricted responses and warns user if too many requests are rejected